### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/mergeToMaster.yaml
+++ b/.github/workflows/mergeToMaster.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           cmd: build
       - name: Publish to quay.io
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ocpmetal/ocp-metal-ui
           username: ${{ secrets.QUAYIO_OCPMETAL_USERNAME }}
@@ -40,7 +40,7 @@ jobs:
           dockerfile: Dockerfile
           tags: 'latest,${{ github.sha }}'
       - name: Publish integration tests to quay.io
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ocpmetal/ocp-metal-ui-tests
           username: ${{ secrets.QUAYIO_OCPMETAL_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           cmd: build
       - name: Publish to quay.io
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ocpmetal/ocp-metal-ui
           username: ${{ secrets.QUAYIO_OCPMETAL_USERNAME }}
@@ -40,7 +40,7 @@ jobs:
           dockerfile: Dockerfile
           tags: 'stable,${{ env.GIT_TAG }},${{ github.sha }}'
       - name: Publish integration tests to quay.io
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ocpmetal/ocp-metal-ui-tests
           username: ${{ secrets.QUAYIO_OCPMETAL_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore